### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/spanners-api/src/main/resources/application.properties
+++ b/spanners-api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
+eureka.client.serviceUrl.defaultZone=https://localhost:8761/eureka/
 
 spring.application.name=spanners-api
 


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists.  

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).